### PR TITLE
fix parsing

### DIFF
--- a/projects/material-dayjs-adapter/src/lib/adapter/dayjs-date-adapter.ts
+++ b/projects/material-dayjs-adapter/src/lib/adapter/dayjs-date-adapter.ts
@@ -295,9 +295,9 @@ export class DayjsDateAdapter extends DateAdapter<Dayjs> {
 
   private dayJs(input?: any, format?: string, locale?: string): Dayjs {
     if (this.shouldUseUtc) {
-      return dayjs(input, { format, locale, utc: this.shouldUseUtc }, locale).utc();
+      return dayjs(input, format, locale).utc();
     } else {
-      return dayjs(input, { format, locale }, locale);
+      return dayjs(input, format, locale);
     }
   }
 


### PR DESCRIPTION
See https://github.com/iamkun/dayjs/issues/1285, the syntax with the second parameter as object seems to be broken, at least on newer versions of dayjs.